### PR TITLE
Fix signed integer problem to properly handle negative temperatures

### DIFF
--- a/addon-vantagepro2mqtt/Dockerfile
+++ b/addon-vantagepro2mqtt/Dockerfile
@@ -7,9 +7,9 @@ RUN \
   apk add --no-cache \
     python3 \
     py3-pip \
-  && pip3 install pyvantagepro \
-  && pip3 install paho-mqtt \
-  && pip3 install colorlog
+  && pip3 install PyVantagePro-MarcoGos --break-system-packages \
+  && pip3 install paho-mqtt --break-system-packages \
+  && pip3 install colorlog --break-system-packages
 
 COPY rootfs /
 


### PR DESCRIPTION
Update the `dockerfile` to use your forked version of pyvantagepro that has the fix for the signed integer temperature to fix the bug with negative temperatures displaying as 6500+ degrees F.  After merge, please re-generate the images on Docker Hub or remove `image: "marcogos/{arch}-addon-vantagepro2mqtt"` from `config.yaml` so the image is auto-generated upon install on HA. 